### PR TITLE
Feature: Linear ancestor traversal

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -31,4 +31,14 @@ class Route < ApplicationRecord
       route.update_columns(attributes.merge(updated_at: Time.current)) # rubocop:disable Rails/SkipsModelValidations
     end
   end
+
+  def split_path_parts
+    paths = []
+
+    path.split('/').each_with_index do |_part, index|
+      paths << path.split('/')[0..index].join('/')
+    end
+
+    paths
+  end
 end

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -12,7 +12,7 @@ module Groups
     end
 
     def execute # rubocop:disable Metrics/AbcSize
-      unless allowed_to_modify_group?(group)
+      unless group.parent.nil? || allowed_to_modify_group?(group.parent)
         raise GroupCreateError, I18n.t('services.groups.create.no_permission',
                                        namespace_type: group.class.model_name.human)
       end

--- a/test/fixtures/routes.yml
+++ b/test/fixtures/routes.yml
@@ -22,6 +22,11 @@ john_doe_namespace_route:
   path: john.doe_at_localhost
   source: john_doe_namespace (Namespace)
 
+jane_doe_namespace_route:
+  name: jane.doe@localhost
+  path: jane.doe_at_localhost
+  source: jane_doe_namespace (Namespace)
+
 project1_namespace_route:
   name: Group 1 / Project 1
   path: group-1/project-1
@@ -36,3 +41,28 @@ john_doe_project2_namespace_route:
   name: john.doe@localhost / Project 2
   path: john.doe_at_localhost/project-2
   source: john_doe_project2_namespace (Namespace)
+
+project3_namespace_route:
+  name: john.doe@localhost / Project 3
+  path: john.doe_at_localhost/project-3
+  source: john_doe_project3_namespace (Namespace)
+
+project4_namespace_route:
+  name: Group 3 / Subgroup 1 Group 3 / Project 4
+  path: group-3/subgroup-1-group-3/project-4
+  source: project4_namespace (Namespace)
+
+group_two_route:
+  name: Group 2
+  path: group-2
+  source: group_two (Namespace)
+
+group_three_route:
+  name: Group 3
+  path: group-3
+  source: group_three (Namespace)
+
+subgroup_one_group_three_route:
+  name: Group 3 / Subgroup 1 Group 3
+  path: group-3/subgroup-1-group-3
+  source: subgroup_one_group_three (Namespace)

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -5,6 +5,8 @@ require 'test_helper'
 class GroupTest < ActiveSupport::TestCase
   def setup
     @group = groups(:group_one)
+    @subgroup_one = groups(:subgroup1)
+    @group_three = groups(:group_three)
   end
 
   test 'valid group' do
@@ -23,8 +25,37 @@ class GroupTest < ActiveSupport::TestCase
     assert_not_nil @subgroup.errors[:parent_id], 'no validation error for parent'
   end
 
+  test '#ancestor_ids' do
+    assert_equal [@group.id], @subgroup_one.ancestor_ids
+  end
+
   test '#ancestors' do
-    assert_equal [], @group.ancestors
+    assert_equal [@group], @subgroup_one.ancestors
+  end
+
+  test '#self_and_ancestors' do
+    assert_includes @subgroup_one.self_and_ancestors, @subgroup_one
+    assert_includes @subgroup_one.self_and_ancestors, @group
+    assert_equal 2, @subgroup_one.self_and_ancestors.count
+  end
+
+  test '#descendant_ids' do
+    assert_includes @group_three.descendant_ids, groups(:subgroup_one_group_three).id
+    assert_includes @group_three.descendant_ids, namespaces_project_namespaces(:project4_namespace).id
+    assert_equal 2, @group_three.descendant_ids.count
+  end
+
+  test '#descendants' do
+    assert_includes @group_three.descendants, groups(:subgroup_one_group_three)
+    assert_includes @group_three.descendants, namespaces_project_namespaces(:project4_namespace)
+    assert_equal 2, @group_three.descendants.count
+  end
+
+  test '#self_and_descendants' do
+    assert_includes @group_three.self_and_descendants, @group_three
+    assert_includes @group_three.self_and_descendants, groups(:subgroup_one_group_three)
+    assert_includes @group_three.self_and_descendants, namespaces_project_namespaces(:project4_namespace)
+    assert_equal 3, @group_three.self_and_descendants.count
   end
 
   test '#human_name' do

--- a/test/models/namespaces/project_namespace_test.rb
+++ b/test/models/namespaces/project_namespace_test.rb
@@ -12,8 +12,28 @@ class ProjectNamespaceTest < ActiveSupport::TestCase
     assert @project_namespace.valid?
   end
 
+  test '#ancestor_ids' do
+    assert_equal [@group_one.id], @project_namespace.ancestor_ids
+  end
+
   test '#ancestors' do
     assert_equal [@group_one], @project_namespace.ancestors
+  end
+
+  test '#self_and_ancestors' do
+    assert_equal [@project_namespace, @group_one], @project_namespace.self_and_ancestors
+  end
+
+  test '#descendant_ids' do
+    assert_equal [],  @project_namespace.descendant_ids
+  end
+
+  test '#descendants' do
+    assert_equal [],  @project_namespace.descendants
+  end
+
+  test '#self_and_descendants' do
+    assert_equal [@project_namespace], @project_namespace.self_and_descendants
   end
 
   test '#human_name' do

--- a/test/models/namespaces/user_namespace_test.rb
+++ b/test/models/namespaces/user_namespace_test.rb
@@ -11,8 +11,41 @@ class UserNamespaceTest < ActiveSupport::TestCase
     assert @user_namespace.valid?
   end
 
+  test '#ancestor_ids' do
+    assert_equal [], @user_namespace.ancestor_ids
+  end
+
   test '#ancestors' do
     assert_equal [], @user_namespace.ancestors
+  end
+
+  test '#self_and_ancestors' do
+    assert_equal [@user_namespace], @user_namespace.self_and_ancestors
+  end
+
+  test '#descendant_ids' do
+    assert_equal [
+      namespaces_project_namespaces(:john_doe_project2_namespace).id,
+      namespaces_project_namespaces(:john_doe_project3_namespace).id
+    ],
+                 @user_namespace.descendant_ids
+  end
+
+  test '#descendants' do
+    assert_equal [
+      namespaces_project_namespaces(:john_doe_project2_namespace),
+      namespaces_project_namespaces(:john_doe_project3_namespace)
+    ],
+                 @user_namespace.descendants
+  end
+
+  test '#self_and_descendants' do
+    assert_equal [
+      @user_namespace,
+      namespaces_project_namespaces(:john_doe_project2_namespace),
+      namespaces_project_namespaces(:john_doe_project3_namespace)
+    ],
+                 @user_namespace.self_and_descendants
   end
 
   test '#human_name' do


### PR DESCRIPTION
Replace recursive traversal of ancestors with linear traversal using route paths.

Fix bug in groups create service, that was passing the group to be created to permission evaluator instead of the parent.